### PR TITLE
bugfix: the log4j2 log file was not written

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /.idea
 /.gradle
 /shuffler/build
-/logs
+**/logs

--- a/shuffler/build.gradle
+++ b/shuffler/build.gradle
@@ -9,10 +9,9 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'org.bitcoinj:bitcoinj-core:0.13.4'
     compile 'com.madgag.spongycastle:core:1.53.0.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.5'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.5'
+    compile 'org.apache.logging.log4j:log4j-api:2.5'
+    compile 'org.apache.logging.log4j:log4j-core:2.5'
 }
 
 project.pmd.ignoreFailures = true
 project.findbugs.ignoreFailures = true
-

--- a/shuffler/src/test/resources/log4j2.xml
+++ b/shuffler/src/test/resources/log4j2.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO" strict="true" name="XMLConfigTest"
+<Configuration status="INFO"
+    strict="true"
+    name="XMLConfigTest"
     packages="org.apache.logging.log4j.test">
     <Properties>
         <Property name="filename">logs/test.log</Property>
     </Properties>
     <Appenders>
-        <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-        </Console>
+        <Appender name="Console" type="Console">
+            <Layout type="PatternLayout" pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Appender>
         <Appender type="File" name="File" fileName="${filename}">
             <Layout type="PatternLayout">
                 <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
             </Layout>
         </Appender>
-        <Appender type="List" name="List">
-        </Appender>
     </Appenders>
     <Loggers>
         <Root level="info">
             <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/shuffler/src/test/resources/log4j2.xml
+++ b/shuffler/src/test/resources/log4j2.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO">
+<Configuration status="INFO" strict="true" name="XMLConfigTest"
+    packages="org.apache.logging.log4j.test">
     <Properties>
         <Property name="filename">logs/test.log</Property>
     </Properties>
@@ -7,14 +8,14 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
         </Console>
+        <Appender type="File" name="File" fileName="${filename}">
+            <Layout type="PatternLayout">
+                <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            </Layout>
+        </Appender>
+        <Appender type="List" name="List">
+        </Appender>
     </Appenders>
-    <Appender type="File" name="File" fileName="${filename}">
-        <Layout type="PatternLayout">
-            <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
-        </Layout>
-    </Appender>
-    <Appender type="List" name="List">
-    </Appender>
     <Loggers>
         <Root level="info">
             <AppenderRef ref="Console"/>


### PR DESCRIPTION
turns out the config file was read but the file appender was not in the appenders node
also harmonized the log4j gradle dependency format